### PR TITLE
Target netstandard2.0 as well

### DIFF
--- a/Source/FeatureSwitcher/FeatureSwitcher.csproj
+++ b/Source/FeatureSwitcher/FeatureSwitcher.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <Description>FeatureSwitcher is little library build to support you when you want to introduce feature switches/toggles in your code.</Description>
     <PackageId>FeatureSwitcher</PackageId>
     <Authors>Max Malook, Marco Rasp, Stefan Senff</Authors>


### PR DESCRIPTION
Really great to see the netstandard support!

I really hope we can add netstandard2.0 as a separate target framework.
Reason is, when you install FeatureSwitcher in a non-Core MVC project which does not support `<PackageReference>`, the reference and package list gets completely polluted:

![image](https://user-images.githubusercontent.com/77322/36279558-be3e6cb2-1297-11e8-93fc-2c149b524f51.png)

However this does not occur if you install a netstandard2.0 library into a .NET 4.7.1 project.
